### PR TITLE
JavaScript: Remove a few more configurations from AllConfigurations.qll.

### DIFF
--- a/javascript/ql/src/Security/Summaries/Configurations.qll
+++ b/javascript/ql/src/Security/Summaries/Configurations.qll
@@ -12,15 +12,10 @@ import semmle.javascript.security.dataflow.CommandInjection
 import semmle.javascript.security.dataflow.DomBasedXss as DomBasedXss
 import semmle.javascript.security.dataflow.NosqlInjection
 import semmle.javascript.security.dataflow.ReflectedXss as ReflectedXss
-import semmle.javascript.security.dataflow.RegExpInjection
-import semmle.javascript.security.dataflow.RemotePropertyInjection
 import semmle.javascript.security.dataflow.ServerSideUrlRedirect
 import semmle.javascript.security.dataflow.SqlInjection
-import semmle.javascript.security.dataflow.StackTraceExposure
 import semmle.javascript.security.dataflow.StoredXss as StoredXss
-import semmle.javascript.security.dataflow.TaintedFormatString
 import semmle.javascript.security.dataflow.TaintedPath
 import semmle.javascript.security.dataflow.UnsafeDeserialization
 import semmle.javascript.security.dataflow.XmlBomb
-import semmle.javascript.security.dataflow.XpathInjection
 import semmle.javascript.security.dataflow.Xxe

--- a/javascript/ql/src/Security/Summaries/ExtractFlowStepSummaries.ql
+++ b/javascript/ql/src/Security/Summaries/ExtractFlowStepSummaries.ql
@@ -9,7 +9,7 @@
  * @id js/step-summary-extraction
  */
 
-import AllConfigurations
+import Configurations
 import PortalExitSource
 import PortalEntrySink
 

--- a/javascript/ql/src/Security/Summaries/ExtractSinkSummaries.ql
+++ b/javascript/ql/src/Security/Summaries/ExtractSinkSummaries.ql
@@ -7,7 +7,7 @@
  * @id js/sink-summary-extraction
  */
 
-import AllConfigurations
+import Configurations
 import PortalExitSource
 import SinkFromAnnotation
 

--- a/javascript/ql/src/Security/Summaries/ExtractSourceSummaries.ql
+++ b/javascript/ql/src/Security/Summaries/ExtractSourceSummaries.ql
@@ -7,7 +7,7 @@
  * @id js/source-summary-extraction
  */
 
-import AllConfigurations
+import Configurations
 import PortalEntrySink
 import SourceFromAnnotation
 


### PR DESCRIPTION
This should hopefully prevent the BDD node exhaustion we get due to the complex type hierarchy caused by importing many configurations at once. I've also renamed the library accordingly.